### PR TITLE
adds street_address column to alerts table

### DIFF
--- a/db/migrate/20230506174112_add_street_address_to_alert.rb
+++ b/db/migrate/20230506174112_add_street_address_to_alert.rb
@@ -1,0 +1,5 @@
+class AddStreetAddressToAlert < ActiveRecord::Migration[6.1]
+  def change
+    add_column :alerts, :street_address, :string, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_15_171915) do
+ActiveRecord::Schema.define(version: 2023_05_06_174112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2021_04_15_171915) do
     t.uuid "area_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "street_address"
     t.index ["area_id"], name: "index_alerts_on_area_id"
   end
 


### PR DESCRIPTION
I figure we can plan to add a checkbox or toggle that allows people to opt out of us saving/associating their street address with their email.

But if we collect and have both, we can choose to annually delete only the alert records that don't have a street address. And for the ones that _do_ have a street address, we can email them and prompt them to confirm, update their address, or unsubscribe.