### PR TITLE
adds street_address column to admin dashboard

### DIFF
--- a/app/admin/alerts.rb
+++ b/app/admin/alerts.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Alert do
-  permit_params :area_id, :email, :phone, :confirmed
+  permit_params :area_id, :email, :phone, :confirmed, :street_address
   actions :all, except: [:show]
   config.sort_order = "created_at_desc"
 
@@ -8,6 +8,9 @@ ActiveAdmin.register Alert do
     column :phone
     column :area do |alert|
       link_to alert.area.name, area_url(alert.area), target: "_blank"
+    end
+    column :street_address do |alert|
+      alert.street_address[0..-19]
     end
     column :confirmed
     column :updated_at


### PR DESCRIPTION
Note: `[0..-19]` hides `, Chicago, IL, USA` from the end of each `street_address` string.