### PR TITLE
adds service object to destroy all alert records that are unconfirmed…

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -23,9 +23,9 @@ class HomeController < ApplicationController
   def set_note
     @note = "Please note that alert subscriptions do not carry over from year to year, unless you save your street address when signing up for notifications."
     if NEW_SCHEDULES_LIVE && !is_january_or_february?
-      @note += "If your address has changed since last year, simply subscribe with your new address and then unsubscribe your old address from an alert email."
+      @note += "If your street address has changed, simply subscribe with your new address and then unsubscribe your old address from an alert email."
     elsif !sweeping_done_for_year? && !NEW_SCHEDULES_LIVE
-      @note += "New schedules will be posted after the City publishes them (typically in March)."
+      @note += "New schedules will be posted after the City publishes them (typically in March), at which point all alert subscriptions that are either unconfirmed or without street addresses will be deleted."
     end
   end
 

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -41,6 +41,17 @@ class AlertMailer < ApplicationMailer
     )
   end
 
+  def deleted_notification
+    @alert = params[:alert]
+    @area = @alert.area
+    @home_url = root_url
+
+    mail(
+      to: @alert.email,
+      subject: "Your street sweeping alert subscription has been canceled",
+    )
+  end
+
   private
 
   def formatted_address_area(street_address, area)

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -11,6 +11,7 @@ class Alert < ApplicationRecord
 
   scope :confirmed, -> { where(confirmed: true) }
   scope :unconfirmed, -> { where(confirmed: false) }
+  scope :without_street_address, -> { where(street_address: nil) }
 
   def self.ransackable_attributes(auth_object = nil)
     %w[area_id confirmed email phone street_address updated_at]

--- a/app/services/destroy_eligible_alerts.rb
+++ b/app/services/destroy_eligible_alerts.rb
@@ -1,0 +1,29 @@
+class DestroyEligibleAlerts
+  attr_reader :alerts_to_destroy, :alerts_to_notify, :write
+
+  def initialize(write: false)
+    @alerts_to_destroy = Alert.without_street_address.or(Alert.unconfirmed)
+    @alerts_to_notify = @alerts_to_destroy.confirmed
+    @write = write
+  end
+
+  def call
+    return "TEST: #{alerts_to_destroy.count} alerts (unconfirmed or without street address) marked for deletion" unless write
+
+    begin
+      send_mailers_to_confirmed_users
+      destroyed_objects = alerts_to_destroy.destroy_all
+      "SUCCESS: #{destroyed_objects.count} alerts (unconfirmed or without street address) deleted"
+    rescue => e
+      "ERROR: Failed to delete alerts - #{e.message}"
+    end
+  end
+
+  private
+
+  def send_mailers_to_confirmed_users
+    alerts_to_notify.each do |alert|
+      AlertMailer.with(alert: alert).deleted_notification.deliver_later
+    end
+  end
+end

--- a/app/views/alert_mailer/deleted_notification.html.erb
+++ b/app/views/alert_mailer/deleted_notification.html.erb
@@ -1,0 +1,14 @@
+<p>Hello,</p>
+
+<p>
+  We've just updated the Chicago street sweeping schedules for the <%= Time.current.year %> season, and wanted to let you know that your subscription for <strong><%= @area.name %></strong> has been canceled. (This is because your subscription did not have a specific street address, and because the City's sweeping areas often change from year to year.)
+</p>
+
+<p>
+  If you'd like to continue receiving alerts for this (or another) area, <%= link_to "please visit our website and re-subscribe", @home_url %>.
+</p>
+
+<p>
+Cheers,<br />
+<%= ENV["SITE_NAME"] %>
+</p>

--- a/app/views/alert_mailer/deleted_notification.text.erb
+++ b/app/views/alert_mailer/deleted_notification.text.erb
@@ -1,0 +1,8 @@
+Hello,
+
+We've just updated the Chicago street sweeping schedules for the <%= Time.current.year %> season, and wanted to let you know that your subscription for <%= @area.name %> has been canceled. (This is because your subscription did not have a specific street address, and because the City's sweeping areas often change from year to year.)
+
+If you'd like to continue receiving alerts for this (or another) area, <%= link_to "please visit our website and re-subscribe", @home_url %>.
+
+Cheers,
+<%= ENV["SITE_NAME"] %>

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -78,4 +78,27 @@ RSpec.describe AlertMailer, type: :mailer do
       end
     end
   end
+
+  describe '#deleted_notification email' do
+    let!(:alert) { create :alert, :confirmed, area: area }
+    let(:mail) do
+      described_class
+        .with(alert: alert)
+        .deleted_notification
+        .deliver_now
+    end
+
+    it 'has the right attributes' do
+      expect(mail.from).to eq(['info@wethesweeple.com'])
+      expect(mail.subject).to eq('Your street sweeping alert subscription has been canceled')
+      expect(mail.to).to include(alert.email)
+      expect(html_body).to include('Hello,')
+      expect(html_body).to include("We've just updated the Chicago street sweeping schedules for the 2023 season, and wanted to let you know that your subscription for <strong>#{area.name}</strong> has been canceled. (This is because your subscription did not have a specific street address, and because the City's sweeping areas often change from year to year.)")
+      expect(html_body).to include("If you'd like to continue receiving alerts for this (or another) area,")
+      expect(html_body).to include(root_url)
+      expect(html_body).to include('Cheers,')
+      expect(html_body).to include(ENV["SITE_NAME"])
+      expect(html_body).to include('https://www.wethesweeple.com')
+    end
+  end
 end

--- a/spec/services/destroy_eligible_alerts_spec.rb
+++ b/spec/services/destroy_eligible_alerts_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DestroyEligibleAlerts, type: :service do
+  describe '.call' do
+    let!(:area) { create(:area) }
+    let!(:alert_confirmed_no_address) { create(:alert, :confirmed, area: area, created_at: 1.year.ago) }
+    let!(:alert_confirmed_with_address) { create(:alert, :confirmed, :with_address, area: area, created_at: 1.year.ago) }
+    let!(:alert_unconfirmed_no_address) { create(:alert, :unconfirmed, area: area, created_at: 1.year.ago) }
+    let!(:alert_unconfirmed_with_address) { create(:alert, :unconfirmed, :with_address, area: area, created_at: 1.year.ago) }
+
+    context 'when write is false' do
+      subject { described_class.new(write: false).call }
+      let(:expected_result) { "TEST: 3 alerts (unconfirmed or without street address) marked for deletion" }
+
+      it 'does not destroy any alerts' do
+        expect { subject }.not_to change { Alert.count }
+        expect(Alert.exists?(alert_confirmed_no_address.id)).to be_truthy
+        expect(Alert.exists?(alert_confirmed_with_address.id)).to be_truthy
+        expect(Alert.exists?(alert_unconfirmed_no_address.id)).to be_truthy
+        expect(Alert.exists?(alert_unconfirmed_with_address.id)).to be_truthy
+      end
+
+      it 'returns test result string' do
+        result = subject
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'when write is true' do
+      subject { described_class.new(write: true).call }
+      let(:expected_result) { "SUCCESS: 3 alerts (unconfirmed or without street address) deleted" }
+      let(:alert_mailer_dbl) { double(AlertMailer) }
+
+      before do
+        allow(AlertMailer).to receive(:with).and_return(alert_mailer_dbl)
+        allow(alert_mailer_dbl).to receive(:deleted_notification).and_return(alert_mailer_dbl)
+        allow(alert_mailer_dbl).to receive(:deliver_later)
+      end
+
+      it 'sends mailers to confirmed alerts to be deleted' do
+        subject
+        expect(AlertMailer).to have_received(:with).with(alert: alert_confirmed_no_address)
+        expect(alert_mailer_dbl).to have_received(:deleted_notification)
+        expect(alert_mailer_dbl).to have_received(:deliver_later)
+      end
+
+      it 'destroys all alerts that are unconfirmed or without street addresses' do
+        expect { subject }.to change { Alert.count }.by(-3)
+        expect(Alert.exists?(alert_confirmed_no_address.id)).to be_falsey
+        expect(Alert.exists?(alert_confirmed_with_address.id)).to be_truthy
+        expect(Alert.exists?(alert_unconfirmed_no_address.id)).to be_falsey
+        expect(Alert.exists?(alert_unconfirmed_with_address.id)).to be_falsey
+      end
+
+      it 'returns success result string' do
+        result = subject
+        expect(result).to eq(expected_result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
… or without street addresses; notifies confirmed users to remind them to re-subscribe