### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete regular expression for hostnames

### DIFF
--- a/spec/services/carry_over_existing_alerts_spec.rb
+++ b/spec/services/carry_over_existing_alerts_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe CarryOverExistingAlerts, type: :service do
     before do
       failure_body = File.read(Rails.root.join('spec', 'fixtures', 'google_maps_failure_response.json'))
 
-      stub_request(:get, /maps.googleapis.com.*invalid/)
+      stub_request(:get, /maps\.googleapis\.com.*invalid/)
         .to_return(body: failure_body)
     end
 


### PR DESCRIPTION
Potential fix for [https://github.com/srobbin/sweeparoundus/security/code-scanning/7](https://github.com/srobbin/sweeparoundus/security/code-scanning/7)

Use an escaped hostname regex in the failing stub so it only matches `maps.googleapis.com` and not arbitrary variants.

Best fix in this file: change line 107 from:

- `stub_request(:get, /maps.googleapis.com.*invalid/)`

to:

- `stub_request(:get, /maps\.googleapis\.com.*invalid/)`

This preserves existing functionality (still matches URLs containing `invalid` after the host) while removing unintended host overmatching. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
