### PR TITLE
Potential fix for code scanning alert no. 49: Incomplete regular expression for hostnames

### DIFF
--- a/spec/services/reverse_geocode_address_spec.rb
+++ b/spec/services/reverse_geocode_address_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ReverseGeocodeAddress, type: :service do
         subject.call
         described_class.new(lat: lat, lng: lng).call
 
-        expect(WebMock).to have_requested(:get, /maps.googleapis.com\/maps\/api\/geocode\/json/).once
+        expect(WebMock).to have_requested(:get, /maps\.googleapis\.com\/maps\/api\/geocode\/json/).once
       end
 
       it "caches a hash wrapper with nil value to distinguish from a cache miss" do


### PR DESCRIPTION
Potential fix for [https://github.com/srobbin/sweeparoundus/security/code-scanning/49](https://github.com/srobbin/sweeparoundus/security/code-scanning/49)

Use a hostname regex with escaped literal dots so only the intended domain matches.

Best fix in this file: update the regex on line 68 from:

- `/maps.googleapis.com\/maps\/api\/geocode\/json/`

to:

- `/maps\.googleapis\.com\/maps\/api\/geocode\/json/`

This preserves existing behavior (matching the same endpoint path) while removing the unintended wildcard behavior in the hostname portion. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
